### PR TITLE
Upgrade SSSD and OS version (#1, #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The command may look similar to this:
 docker run --rm \
   -v ./config/sssd/sssd.conf.example:/etc/sssd/sssd.conf \
   -v ./path/to/ldap/cert.pem:/etc/ssl/certs/ldap_cert_1.pem \
-  -v ./path/to/ldap/cert.pem:/etc/ssl/certs/ldap_cert_1.pem \
+  -v ./path/to/ldap/cert.pem:/etc/ssl/certs/ldap_cert_2.pem \
   -it ghcr.io/bihealth/sssd-docker:latest
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,19 @@ This is a Docker image from CUBI @bihealth that we use for our iRODS deployment.
 $ bash build.sh
 ```
 
+## Running
+
+Edit the file `config/sssd/sssd.conf.example`, then run the container with bind-mounts for the SSSD configuration file and LDAP TLS certificates (if needed).
+The command may look similar to this:
+
+```bash
+docker run --rm \
+  -v ./config/sssd/sssd.conf.example:/etc/sssd/sssd.conf \
+  -v ./path/to/ldap/cert.pem:/etc/ssl/certs/ldap_cert_1.pem \
+  -v ./path/to/ldap/cert.pem:/etc/ssl/certs/ldap_cert_1.pem \
+  -it ghcr.io/bihealth/sssd-docker:latest
+```
+
 ## Data Persistency
 
 Each container exposes volumes for data persistency.

--- a/config/sssd/sssd.conf.example
+++ b/config/sssd/sssd.conf.example
@@ -15,6 +15,7 @@ offline_credentials_expiration = 3
 id_provider = ldap
 auth_provider = ldap
 access_provider = ldap
+sudo_provider = none
 
 ldap_uri = ldaps://ldap.example1.com:636
 ldap_id_use_start_tls = false
@@ -47,6 +48,7 @@ debug_level = 1
 id_provider = ldap
 auth_provider = ldap
 access_provider = ldap
+sudo_provider = none
 
 ldap_uri = ldap://ldap.example2.com:3268
 ldap_id_use_start_tls = true

--- a/config/sssd/sssd.conf.example
+++ b/config/sssd/sssd.conf.example
@@ -1,0 +1,74 @@
+[sssd]
+
+config_file_version = 2
+domains = DOMAIN1, DOMAIN2
+services = nss, pam
+
+
+[pam]
+
+offline_credentials_expiration = 3
+
+
+[domain/DOMAIN1]
+
+id_provider = ldap
+auth_provider = ldap
+access_provider = ldap
+
+ldap_uri = ldaps://ldap.example1.com:636
+ldap_id_use_start_tls = false
+ldap_tls_reqcert = demand
+ldap_tls_cacert = /path/to/my/cert1.pem
+ldap_search_base = MY_SEARCH_BASE_1
+ldap_default_bind_dn = MY_BIND_DN_1
+ldap_default_authtok = MY_LDAP_PASSWORD_1
+ldap_default_authtok_type = password
+ldap_access_filter = objectClass=person
+ldap_schema = ad
+ldap_user_objectsid = objectSid
+ldap_user_object_class = person
+ldap_user_name = sAMAccountName
+ldap_user_fullname = displayName
+ldap_id_mapping = true
+
+cache_credentials = true
+account_cache_expiration = 7
+entry_cache_timeout = 14400
+
+use_fully_qualified_names = true
+ignore_group_members = true
+
+debug_level = 1
+
+
+[domain/DOMAIN2]
+
+id_provider = ldap
+auth_provider = ldap
+access_provider = ldap
+
+ldap_uri = ldap://ldap.example2.com:3268
+ldap_id_use_start_tls = true
+ldap_tls_reqcert = demand
+ldap_tls_cacert = /path/to/my/cert2.pem
+ldap_search_base = MY_SEARCH_BASE_2
+ldap_default_bind_dn = MY_BIND_DN_2
+ldap_default_authtok = MY_LDAP_PASSWORD_2
+ldap_default_authtok_type = password
+ldap_access_filter = objectClass=person
+ldap_schema = ad
+ldap_user_objectsid = objectSid
+ldap_user_object_class = person
+ldap_user_name = sAMAccountName
+ldap_user_fullname = displayName
+ldap_id_mapping = true
+
+cache_credentials = true
+account_cache_expiration = 7
+entry_cache_timeout = 14400
+
+use_fully_qualified_names = true
+ignore_group_members = true
+
+debug_level = 1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,21 +1,22 @@
-# Build container running sssd on CentOS 7.
-FROM centos:7
+# Build container running sssd on Debian.
+FROM debian:bookworm
 
 LABEL org.opencontainers.image.source https://github.com/bihealth/sssd-docker
 
-# Cleanup software package and install latest updates.
-RUN yum clean all && \
-    yum upgrade -y
+ENV DEBIAN_FRONTEND=noninteractive
 
-# Install SSSD.
-RUN yum install -y \
+# Install system packages.
+RUN apt-get update && \
+    apt-get install -y \
         sssd \
         sssd-ldap \
         sssd-tools
 
+# Set the working directory.
+WORKDIR /usr/local/bin
+
 # Define the entry point.
 COPY docker-entrypoint.sh /usr/local/bin
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh && \
-    ln -s /usr/local/bin/docker-entrypoint.sh / # backwards compat
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["sssd"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,16 +1,17 @@
 # Build container running sssd on Debian.
 FROM debian:bookworm
 
-LABEL org.opencontainers.image.source https://github.com/bihealth/sssd-docker
+LABEL org.opencontainers.image.source=https://github.com/bihealth/sssd-docker
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install system packages.
+# Install system packages and pin their version.
 RUN apt-get update && \
     apt-get install -y \
-        sssd \
-        sssd-ldap \
-        sssd-tools
+        'sssd=2.8.*' \
+        'sssd-ldap=2.8.*' \
+        'sssd-tools=2.8.*'
+RUN apt-mark hold sssd sssd-ldap sssd-tools
 
 # Set the working directory.
 WORKDIR /usr/local/bin

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -2,45 +2,10 @@
 
 set -euo pipefail
 
-init-var-lib()
-(
-  LIB=/var/lib/sss
-
-  mkdir -p ${LIB}/sss/{deskprofile,pipes/private,mc,db,keytabs,gpo_cache,secrets,pubconf/krb5.include.d}
-
-  chown root:root ${LIB}/sss
-  chown root:root ${LIB}/sss/deskprofile
-  chown sssd:sssd ${LIB}/sss/pipes
-  chown sssd:sssd ${LIB}/sss/pipes/private
-  chown sssd:sssd ${LIB}/sss/mc
-  chown sssd:sssd ${LIB}/sss/db
-  chown sssd:sssd ${LIB}/sss/keytabs
-  chown sssd:sssd ${LIB}/sss/gpo_cache
-  chown root:root ${LIB}/sss/secrets
-  chown sssd:sssd ${LIB}/sss/pubconf
-  chown sssd:sssd ${LIB}/sss/pubconf/krb5.include.d
-
-  chmod 755 ${LIB}/sss
-  chmod 755 ${LIB}/sss/deskprofile
-  chmod 755 ${LIB}/sss/pipes
-  chmod 750 ${LIB}/sss/pipes/private
-  chmod 775 ${LIB}/sss/mc
-  chmod 700 ${LIB}/sss/db
-  chmod 700 ${LIB}/sss/keytabs
-  chmod 755 ${LIB}/sss/gpo_cache
-  chmod 700 ${LIB}/sss/secrets
-  chmod 755 ${LIB}/sss/pubconf
-  chmod 755 ${LIB}/sss/pubconf/krb5.include.d
-)
-
-for x in /etc/sssd.in/*; do
-  cp $x /etc/sssd
-  chown root:root /etc/sssd/$(basename $x)
-  chmod u=rw,go= /etc/sssd/$(basename $x)
-done
+chown root:root /etc/sssd/sssd.conf
+chmod 600 /etc/sssd/sssd.conf
 
 if [[ "$1" == sssd ]]; then
-  init-var-lib
   exec sssd -i --logger=stderr
 else
   exec "$@"


### PR DESCRIPTION
This PR attempts to address #1 and #2. It uses Debian bookworm as the base image and the SSSD version that comes with it (currently 2.8.2). I have also included an example configuration file. The `init-var-lib` function doesn't seem to be necessary with newer versions, but the perms on sssd.conf must still be 600.

However, it seems that SSSD is only required by iRODS. Should we consider installing SSSD directly in the docker-irods container, instead of having a separate repository?